### PR TITLE
Fix issue finding the Boost include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if (NOT KACTIVITIES_LIBRARY_ONLY)
    include_directories (
       ${CMAKE_CURRENT_BINARY_DIR}
       ${CMAKE_CURRENT_SOURCE_DIR}
-      ${Boost_INCLUDE_DIR}
+      ${Boost_INCLUDE_DIRS}
       )
    add_subdirectory (imports)
 endif ()


### PR DESCRIPTION
Replaces ${Boost_INCLUDE_DIR} with ${Boost_INCLUDE_DIRS}.